### PR TITLE
Improve form logic

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -2,13 +2,18 @@
 import { programs } from './Services.js';
 
 function collectHouseholdData() {
-  // TODO: replace with actual logic
-  return [];
+  const members = document.querySelectorAll('#members .member');
+  return Array.from(members).map(m => {
+    const age = parseInt(m.querySelector('input[name="age"]').value, 10) || 0;
+    const pregnant = m.querySelector('input[name="pregnant"]').checked;
+    const snap = m.querySelector('input[name="snap"]').checked;
+    return { age, pregnant, snap };
+  });
 }
 
 function getClientIncomeAnnual() {
-  // TODO: replace with actual logic
-  return 0;
+  const incomeInput = document.getElementById('incomeAnnual');
+  return incomeInput ? parseFloat(incomeInput.value) || 0 : 0;
 }
 
 export function checkEligibility() {
@@ -27,3 +32,27 @@ export function checkEligibility() {
 
 // expose checkEligibility to the global scope for inline call
 window.checkEligibility = checkEligibility;
+
+// Dynamic member addition
+document.addEventListener('DOMContentLoaded', () => {
+  const addBtn = document.getElementById('add-member');
+  if (!addBtn) return;
+  addBtn.addEventListener('click', () => {
+    const container = document.getElementById('members');
+    const div = document.createElement('div');
+    div.className = 'member compact-member';
+    div.innerHTML = `
+      <label>Age
+        <input type="number" name="age" min="0" required>
+      </label>
+      <label>
+        <input type="checkbox" name="pregnant">
+        Pregnant
+      </label>
+      <label>
+        <input type="checkbox" name="snap">
+        Receives SNAP
+      </label>`;
+    container.appendChild(div);
+  });
+});


### PR DESCRIPTION
## Summary
- parse household members into objects
- read annual income from the form
- allow adding multiple household member groups dynamically

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686dff2018cc83219c0a3e51b8d43f0f