### PR TITLE
Add basic test framework with Node test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@
 
 ## Customizing Eligibility Logic
 - Edit `/js/Services.js` to modify criteria in each program's `isEligible()`.
+
+## Running Tests
+This project uses Node's built-in test runner. After cloning the repo and
+installing Node 20 or later, run:
+
+```bash
+npm test
+```
+
+All tests in the `test/` directory will execute and verify the sample
+eligibility logic.

--- a/js/Services.js
+++ b/js/Services.js
@@ -1,6 +1,6 @@
 
 // Example programs; add your own or modify as needed!
-const programs = [
+export const programs = [
   {
     name: "SNAP",
     description: "Supplemental Nutrition Assistance Program",
@@ -26,7 +26,7 @@ const programs = [
 ];
 
 // FPL calculation (match script.js if needed)
-function calculateFPL(percent, size) {
+export function calculateFPL(percent, size) {
   const base = 15000 + 6000 * (size - 1);
   return (base * percent) / 100;
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "chp-eligibility-form",
+  "version": "1.0.0",
+  "description": "Eligibility form demo",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test/services.test.js
+++ b/test/services.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { programs } from '../js/Services.js';
+
+function runEligibility(data) {
+  return programs.filter(p => p.isEligible(data)).map(p => p.name);
+}
+
+// Data with SNAP participant
+const snapData = {
+  household: [{ snap: true }],
+  clientIncome: 40000,
+};
+
+// Data with young child and low income
+const wicData = {
+  household: [{ age: 3 }],
+  clientIncome: 25000,
+};
+
+// Data not eligible for any program
+const noneData = {
+  household: [{ age: 30 }],
+  clientIncome: 50000,
+};
+
+test('SNAP eligibility when household member already receives SNAP', () => {
+  assert.deepEqual(runEligibility(snapData), ['SNAP']);
+});
+
+test('WIC eligibility when household has young child and low income', () => {
+  assert.deepEqual(runEligibility(wicData), ['WIC']);
+});
+
+test('No eligibility for unrelated household', () => {
+  assert.deepEqual(runEligibility(noneData), []);
+});


### PR DESCRIPTION
## Summary
- export `programs` from `Services.js`
- setup `package.json` with Node's test runner
- add sample tests for eligibility logic
- document how to run tests in `README`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686dfc2026b88321a49fe6e127a98116